### PR TITLE
BE - landlord account verification

### DIFF
--- a/HouseIt-Backend/src/main/java/HouseIt/controller/AdministratorController.java
+++ b/HouseIt-Backend/src/main/java/HouseIt/controller/AdministratorController.java
@@ -21,11 +21,22 @@ public class AdministratorController {
     @Autowired
     private AdministratorService administratorService;
 
-    @PutMapping(value = {"/verify-landlord/{landlordId}", "/verify-landlord/{landlordId}/"})
-    public ResponseEntity<?> verifyLandlord(@PathVariable int landlordId) {
+    @PutMapping(value = {"/approve-landlord/{landlordId}", "/approve-landlord/{landlordId}/"})
+    public ResponseEntity<?> approveLandlord(@PathVariable int landlordId) {
         // TODO: Authenticate administrator
         try {
-            administratorService.verifyLandlord(landlordId);
+            administratorService.approveLandlord(landlordId);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PutMapping(value = {"/reject-landlord/{landlordId}", "/reject-landlord/{landlordId}/"})
+    public ResponseEntity<?> rejectLandlord(@PathVariable int landlordId) {
+        // TODO: Authenticate administrator
+        try {
+            administratorService.rejectLandlord(landlordId);
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }

--- a/HouseIt-Backend/src/main/java/HouseIt/controller/AdministratorController.java
+++ b/HouseIt-Backend/src/main/java/HouseIt/controller/AdministratorController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import HouseIt.model.User.AccountStatus;
 import HouseIt.service.AdministratorService;
 
 import org.springframework.web.bind.annotation.PutMapping;
@@ -22,11 +21,11 @@ public class AdministratorController {
     @Autowired
     private AdministratorService administratorService;
 
-    @PutMapping(value = {"/verify-landlord/{landlordId}/{newStatus}", "/verify-landlord/{landlordId}/{newStatus}/"})
-    public ResponseEntity<?> verifyLandlord(@PathVariable int landlordId, @PathVariable AccountStatus newStatus) {
+    @PutMapping(value = {"/verify-landlord/{landlordId}", "/verify-landlord/{landlordId}/"})
+    public ResponseEntity<?> verifyLandlord(@PathVariable int landlordId) {
         // TODO: Authenticate administrator
         try {
-            administratorService.verifyLandlord(landlordId, newStatus);
+            administratorService.verifyLandlord(landlordId);
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }

--- a/HouseIt-Backend/src/main/java/HouseIt/controller/AdministratorController.java
+++ b/HouseIt-Backend/src/main/java/HouseIt/controller/AdministratorController.java
@@ -1,0 +1,35 @@
+package HouseIt.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import HouseIt.model.User.AccountStatus;
+import HouseIt.service.AdministratorService;
+
+import org.springframework.web.bind.annotation.PutMapping;
+
+
+@CrossOrigin(origins = "*")
+@RestController
+@RequestMapping("/admin")
+public class AdministratorController {
+    
+    @Autowired
+    private AdministratorService administratorService;
+
+    @PutMapping(value = {"/verify-landlord/{landlordId}/{newStatus}", "/verify-landlord/{landlordId}/{newStatus}/"})
+    public ResponseEntity<?> verifyLandlord(@PathVariable int landlordId, @PathVariable AccountStatus newStatus) {
+        // TODO: Authenticate administrator
+        try {
+            administratorService.verifyLandlord(landlordId, newStatus);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/HouseIt-Backend/src/main/java/HouseIt/service/AdministratorService.java
+++ b/HouseIt-Backend/src/main/java/HouseIt/service/AdministratorService.java
@@ -1,0 +1,33 @@
+package HouseIt.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import HouseIt.dao.LandlordDAO;
+import HouseIt.model.Landlord;
+import HouseIt.model.User.AccountStatus;
+
+@Service
+public class AdministratorService {
+
+    @Autowired
+    private LandlordDAO landlordDAO;
+
+    @Transactional
+    public void verifyLandlord(int landlordId, AccountStatus status) {
+        Landlord landlord = landlordDAO.findLandlordById(landlordId);
+        if (landlord == null) {
+            throw new IllegalArgumentException("No such landlord with id: " + landlordId);
+        }
+        if (landlord.getStatus() == AccountStatus.ACTIVE) {
+            throw new IllegalArgumentException("This account has already been approved");
+        }
+
+        landlord.setStatus(status);
+        landlordDAO.save(landlord);
+
+        // TODO: Notify the landlord
+    }
+
+}

--- a/HouseIt-Backend/src/main/java/HouseIt/service/AdministratorService.java
+++ b/HouseIt-Backend/src/main/java/HouseIt/service/AdministratorService.java
@@ -15,7 +15,7 @@ public class AdministratorService {
     private LandlordDAO landlordDAO;
 
     @Transactional
-    public void verifyLandlord(int landlordId, AccountStatus status) {
+    public void verifyLandlord(int landlordId) {
         Landlord landlord = landlordDAO.findLandlordById(landlordId);
         if (landlord == null) {
             throw new IllegalArgumentException("No such landlord with id: " + landlordId);
@@ -24,7 +24,7 @@ public class AdministratorService {
             throw new IllegalArgumentException("This account has already been approved");
         }
 
-        landlord.setStatus(status);
+        landlord.setStatus(AccountStatus.ACTIVE);
         landlordDAO.save(landlord);
 
         // TODO: Notify the landlord

--- a/HouseIt-Backend/src/main/java/HouseIt/service/AdministratorService.java
+++ b/HouseIt-Backend/src/main/java/HouseIt/service/AdministratorService.java
@@ -15,7 +15,7 @@ public class AdministratorService {
     private LandlordDAO landlordDAO;
 
     @Transactional
-    public void verifyLandlord(int landlordId) {
+    public void approveLandlord(int landlordId) {
         Landlord landlord = landlordDAO.findLandlordById(landlordId);
         if (landlord == null) {
             throw new IllegalArgumentException("No such landlord with id: " + landlordId);
@@ -25,6 +25,22 @@ public class AdministratorService {
         }
 
         landlord.setStatus(AccountStatus.ACTIVE);
+        landlordDAO.save(landlord);
+
+        // TODO: Notify the landlord
+    }
+
+    @Transactional
+    public void rejectLandlord(int landlordId) {
+        Landlord landlord = landlordDAO.findLandlordById(landlordId);
+        if (landlord == null) {
+            throw new IllegalArgumentException("No such landlord with id: " + landlordId);
+        }
+        if (landlord.getStatus() == AccountStatus.DENIED) {
+            throw new IllegalArgumentException("This account has already been rejected");
+        }
+
+        landlord.setStatus(AccountStatus.DENIED);
         landlordDAO.save(landlord);
 
         // TODO: Notify the landlord


### PR DESCRIPTION
Sprint B Week 1 Task List - Entry 9 - BE - Implement Landlord Verification Status

Added backend logic so that the admin can approve/reject a landlord account.

To approve a landlord account: `PUT http://localhost:8080/admin/approve-landlord/{id}`

To reject a landlord account: `PUT http://localhost:8080/admin/reject-landlord/{id}`

To test:
1. Create a landlord: `POST http://localhost:8080/landlord?username=bob&password=hi1234&email=bob@gmail.com&phoneNumber=1234567890`
2. Call one of the endpoints above to approve/reject the landlord
3. Check the new status of the landlord in the database